### PR TITLE
Fix ansible playbook to look for correct GPU label

### DIFF
--- a/playbooks/setup/gpu-taint.ansible.yml
+++ b/playbooks/setup/gpu-taint.ansible.yml
@@ -3,11 +3,32 @@
   vars:
     repo_dir: "{{ lookup('env', 'REPO_DIR') | default(playbook_dir | dirname | dirname, true) }}"
   tasks:
+    - name: Get GPU nodes with nvidia.com/gpu.present=true label
+      shell: |
+        oc get nodes -l nvidia.com/gpu.present=true --no-headers | wc -l
+      register: gpu_node_count
+      changed_when: false
+
+    - name: Print total number of GPU nodes that will be tainted
+      debug:
+        msg: "Total GPU nodes with nvidia.com/gpu.present=true label: {{ gpu_node_count.stdout }}"
+
+    - name: List GPU nodes that will be tainted
+      shell: |
+        oc get nodes -l nvidia.com/gpu.present=true -o jsonpath='{.items[*].metadata.name}'
+      register: gpu_node_names
+      changed_when: false
+
+    - name: Print GPU node names
+      debug:
+        msg: "GPU nodes to be tainted: {{ gpu_node_names.stdout.split() }}"
+      when: gpu_node_names.stdout != ""
+
     - name: Taint nodes
       shell: |
-        oc adm taint node -l node-role.kubernetes.io/gpu nvidia.com/gpu=:NoSchedule --overwrite
-        oc adm drain -l node-role.kubernetes.io/gpu --ignore-daemonsets --delete-emptydir-data
-        oc adm uncordon -l node-role.kubernetes.io/gpu-headers
+        oc adm taint node -l nvidia.com/gpu.present=true nvidia.com/gpu=:NoSchedule --overwrite
+        oc adm drain -l nvidia.com/gpu.present=true --ignore-daemonsets --delete-emptydir-data
+        oc adm uncordon -l nvidia.com/gpu.present=true-headers
       register: taint_gpu_nodes
       retries: 10
       delay: 10
@@ -16,7 +37,7 @@
 
     - name: Verify GPU nodes are tainted
       shell: |
-        oc get nodes -l node-role.kubernetes.io/gpu -o jsonpath='{.items[*].spec.taints}'
+        oc get nodes -l nvidia.com/gpu.present=true -o jsonpath='{.items[*].spec.taints}'
       register: gpu_node_taints
       retries: 5
       delay: 5
@@ -30,7 +51,7 @@
 
     - name: Uncordon all GPU nodes
       shell: |
-        for node in $(oc get nodes -l node-role.kubernetes.io/gpu -o name | awk -F/ '{print $2}'); do
+        for node in $(oc get nodes -l nvidia.com/gpu.present=true -o name | awk -F/ '{print $2}'); do
           oc adm uncordon "$node"
         done
       register: uncordon_gpu_nodes
@@ -41,7 +62,7 @@
 
     - name: Verify GPU nodes are ready
       shell: |
-        oc get nodes -l node-role.kubernetes.io/gpu -o jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].status}'
+        oc get nodes -l nvidia.com/gpu.present=true -o jsonpath='{.items[*].status.conditions[?(@.type=="Ready")].status}'
       register: gpu_node_ready
       retries: 5
       delay: 5

--- a/playbooks/setup/gpu-timeslicing.ansible.yml
+++ b/playbooks/setup/gpu-timeslicing.ansible.yml
@@ -2,7 +2,7 @@
   hosts: localhost
   vars:
     repo_dir: "{{ lookup('env', 'REPO_DIR') | default(playbook_dir | dirname | dirname, true) }}"
-    gpu_worker_labels: "node-role.kubernetes.io/gpu,node-role.kubernetes.io/worker,nvidia.com/gpu.replicas=8,nvidia.com/gpu.sharing-strategy=time-slicing"
+    gpu_worker_labels: "nvidia.com/gpu.present=true,node-role.kubernetes.io/worker,nvidia.com/gpu.replicas=8,nvidia.com/gpu.sharing-strategy=time-slicing"
   tasks:
     - name: Apply 05-gpu-timeslicing kustomize manifests
       shell: "oc apply -k {{ repo_dir }}/components/05-gpu-timeslicing"
@@ -13,7 +13,7 @@
 
     - name: Get all GPU worker nodes
       shell: |
-        oc get nodes -l node-role.kubernetes.io/gpu,node-role.kubernetes.io/worker -o name
+        oc get nodes -l nvidia.com/gpu.present=true,node-role.kubernetes.io/worker -o name
       register: gpu_worker_nodes
 
     - name: Get GPU worker nodes with required labels


### PR DESCRIPTION
- When looking for GPU nodes, look for label `nvidia.com/gpu.present=true` (which is created by NFD and NVIDIA operator) instead of label `node-role.kubernetes.io/gpu`